### PR TITLE
Facilitar el uso

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,17 @@ Herramienta para descargar fotos y mensajes privados de la red social Tuenti.
 
 ## Requisitos
 - Java 7 o superior
+- Maven
+
+## Uso
+Para iniciar el programa:
+
+    mvn exec:java
+    
+Para crear un .jar ejecutable con todas las dependencias:
+
+    mvn assembly:single
+
 
 ## Creadores
 **Jose Toro**

--- a/pom.xml
+++ b/pom.xml
@@ -107,15 +107,54 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.1.1</version>
+        <configuration>
+          <mainClass>io.callate.main.Main</mainClass>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>2.3.1</version>
+        <configuration>
+          <archive>
+            <manifest>
+              <mainClass>io.callate.main.Main</mainClass>
+              <addClasspath>true</addClasspath>
+              <classpathLayoutType>custom</classpathLayoutType>
+              <customClasspathLayout>
+                lib/$${artifact.artifactId}-$${artifact.version}$${dashClassifier?}.$${artifact.extension}
+              </customClasspathLayout>
+            </manifest>
+          </archive>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.3</version>
+        <configuration>
+          <outputDirectory>${project.build.directory}/lib</outputDirectory>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
-      <resources>
-          <resource>
-              <directory>.</directory>
-              <includes>
-                  <include>**/*.png</include>
-              </includes>
-          </resource>
-      </resources>
+    <resources>
+      <resource>
+        <directory>.</directory>
+        <includes>
+          <include>**/*.png</include>
+        </includes>
+      </resource>
+    </resources>
   </build>
   <reporting>
     <plugins>


### PR DESCRIPTION
Unico requisito es maven, no hace falta instalar sbt, las dependencias se manejan solas. En el caso del JAR, las dependencias se incluyen dentro.
